### PR TITLE
[FIX] correct cache map key for usb hub devices

### DIFF
--- a/source/Htc.Vita.Core/IO/UsbManager.Windows.cs
+++ b/source/Htc.Vita.Core/IO/UsbManager.Windows.cs
@@ -703,9 +703,9 @@ namespace Htc.Vita.Core.IO
 
             internal static List<DeviceInfo> GetUsbHubDevicesInPlatform()
             {
-                if (DeviceListMap.ContainsKey(DeviceListMapKeyUsb))
+                if (DeviceListMap.ContainsKey(DeviceListMapKeyUsbHub))
                 {
-                    var pair = DeviceListMap[DeviceListMapKeyUsb];
+                    var pair = DeviceListMap[DeviceListMapKeyUsbHub];
                     if ((DateTime.UtcNow - pair.Key).Duration() < TimeSpan.FromSeconds(5))
                     {
                         return pair.Value;


### PR DESCRIPTION
correct cache map key for usb hub devices